### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/readme.css
+++ b/readme.css
@@ -59,7 +59,7 @@ showdiv.css
 	classes and ids (works well with debugwithoutline.css)
 
 showstructure.css
-	like showdiv.css but it will show you all classes and structures appart
+	like showdiv.css but it will show you all classes and structures apart
 	from divs (works well with showdiv.css and/or debugwithoutline.css
 
 showsitelayout.css


### PR DESCRIPTION
@bitweaver, I've corrected a typographical error in the documentation of the [theme_blank](https://github.com/bitweaver/theme_blank) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
